### PR TITLE
fix: gmock work around

### DIFF
--- a/cmake/modules/FindGMock.cmake
+++ b/cmake/modules/FindGMock.cmake
@@ -54,7 +54,8 @@ if(NOT GMock_FOUND)
     if(GMOCK_SRC_DIR)
       # If src version found, build it.
       if(NOT TARGET gmock)
-        add_subdirectory(${GMOCK_SRC_DIR} "${CMAKE_CURRENT_BINARY_DIR}/gmock")
+        add_subdirectory(${GMOCK_SRC_DIR} "${CMAKE_CURRENT_BINARY_DIR}/gmock"
+          EXCLUDE_FROM_ALL)
       endif()
       # The next line is needed for Ubuntu Trusty.
       set(GMOCK_INCLUDE_DIRS "${GMOCK_SRC_DIR}/gtest/include")

--- a/cmake/modules/FindGMock.cmake
+++ b/cmake/modules/FindGMock.cmake
@@ -12,58 +12,64 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-find_path(GMOCK_INCLUDE_DIRS gmock/gmock.h
-  HINTS
-    ENV GMOCK_DIR
-  PATH_SUFFIXES include
-  PATHS
-    /usr
-)
-
-# Find system-wide installed gmock.
-find_library(GMOCK_LIBRARIES
-  NAMES gmock_main
-  HINTS
-    ENV GMOCK_DIR
-  PATH_SUFFIXES lib
-  PATHS
-    /usr
-)
-
-# Find system-wide gtest header.
-find_path(GTEST_INCLUDE_DIRS gtest/gtest.h
-  HINTS
-    ENV GTEST_DIR
-  PATH_SUFFIXES include
-  PATHS
-    /usr
-)
-list(APPEND GMOCK_INCLUDE_DIRS ${GTEST_INCLUDE_DIRS})
-
-if(NOT GMOCK_LIBRARIES)
-  # If no system-wide gmock found, then find src version.
-  # Ubuntu might have this.
-  find_path(GMOCK_SRC_DIR src/gmock.cc
+if(NOT GMock_FOUND)
+  find_path(GMOCK_INCLUDE_DIRS gmock/gmock.h
     HINTS
       ENV GMOCK_DIR
+    PATH_SUFFIXES include
     PATHS
-      /usr/src/googletest/googlemock
-      /usr/src/gmock
+      /usr
   )
-  if(GMOCK_SRC_DIR)
-    # If src version found, build it.
-    add_subdirectory(${GMOCK_SRC_DIR} "${CMAKE_CURRENT_BINARY_DIR}/gmock")
-    # The next line is needed for Ubuntu Trusty.
-    set(GMOCK_INCLUDE_DIRS "${GMOCK_SRC_DIR}/gtest/include")
-    set(GMOCK_LIBRARIES gmock_main)
-  endif()
-endif()
 
-# System-wide installed gmock library might require pthreads.
-find_package(Threads REQUIRED)
-list(APPEND GMOCK_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
+  # Find system-wide installed gmock.
+  find_library(GMOCK_LIBRARIES
+    NAMES gmock_main
+    HINTS
+      ENV GMOCK_DIR
+    PATH_SUFFIXES lib
+    PATHS
+      /usr
+  )
+
+  # Find system-wide gtest header.
+  find_path(GTEST_INCLUDE_DIRS gtest/gtest.h
+    HINTS
+      ENV GTEST_DIR
+    PATH_SUFFIXES include
+    PATHS
+      /usr
+  )
+  list(APPEND GMOCK_INCLUDE_DIRS ${GTEST_INCLUDE_DIRS})
+
+  if(NOT GMOCK_LIBRARIES)
+    # If no system-wide gmock found, then find src version.
+    # Ubuntu might have this.
+    find_path(GMOCK_SRC_DIR src/gmock.cc
+      HINTS
+        ENV GMOCK_DIR
+      PATHS
+        /usr/src/googletest/googlemock
+        /usr/src/gmock
+    )
+    if(GMOCK_SRC_DIR)
+      # If src version found, build it.
+      if(NOT TARGET gmock)
+        add_subdirectory(${GMOCK_SRC_DIR} "${CMAKE_CURRENT_BINARY_DIR}/gmock")
+      endif()
+      # The next line is needed for Ubuntu Trusty.
+      set(GMOCK_INCLUDE_DIRS "${GMOCK_SRC_DIR}/gtest/include")
+      set(GMOCK_LIBRARIES gmock_main)
+    endif()
+  endif()
+
+  # System-wide installed gmock library might require pthreads.
+  find_package(Threads REQUIRED)
+  list(APPEND GMOCK_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
+endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(GMock DEFAULT_MSG GMOCK_LIBRARIES
                                   GMOCK_INCLUDE_DIRS)
 
+# Mitigate build issue with Catkin
+set(GMOCK_FOUND FALSE)


### PR DESCRIPTION
### What I did
Recently, a workaround has been pushed to cartographer and catkin making it impossible for us to compile cartographer_ros. Jenkins is currently failing with this error (same on my machine):
```
CMake Error at /opt/ros/kinetic/share/catkin/cmake/test/gtest.cmake:381 (add_library):
  add_library cannot create imported target "gmock" because another target
  with the same name already exists.
Call Stack (most recent call first):
  /opt/ros/kinetic/share/catkin/cmake/all.cmake:147 (include)
  /opt/ros/kinetic/share/catkin/cmake/catkinConfig.cmake:20 (include)
  CMakeLists.txt:45 (find_package)


CMake Error at /opt/ros/kinetic/share/catkin/cmake/test/gtest.cmake:383 (add_library):
  add_library cannot create imported target "gmock_main" because another
  target with the same name already exists.
Call Stack (most recent call first):
  /opt/ros/kinetic/share/catkin/cmake/all.cmake:147 (include)
  /opt/ros/kinetic/share/catkin/cmake/catkinConfig.cmake:20 (include)
  CMakeLists.txt:45 (find_package)
```

Those patches taken from upstream are solving it.
One note though. It does compile in a docker container but not on my machine. I would be glad if the reviewers could test it on their machines to confirm the patch does work and it's my machine's issue.

### DO NOT MERGE BEFORE
Here is what I get on my machine:
```
Errors     << cartographer_rviz:make /home/david/Development/lona/dev/LONA-platform2/my_workspace/logs/cartographer_rviz/build.make.007.log                                                            
/usr/bin/ld: /usr/local/lib/libglog.a(libglog_la-logging.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a shared object; recompile with -fPIC
/usr/local/lib/libglog.a: error adding symbols: Bad value
collect2: error: ld returned 1 exit status
make[2]: *** [/home/david/Development/lona/dev/LONA-platform2/my_workspace/devel/.private/cartographer_rviz/lib/libcartographer_rviz.so] Error 1
make[1]: *** [CMakeFiles/cartographer_rviz.dir/all] Error 2
make: *** [all] Error 2
cd /home/david/Development/lona/d
```